### PR TITLE
Fix: Correct string note calculation bug on fretboard

### DIFF
--- a/src/design-system/components/Fretboard/Fretboard.test.tsx
+++ b/src/design-system/components/Fretboard/Fretboard.test.tsx
@@ -156,13 +156,13 @@ describe('Fretboard Component', () => {
         note: 'G'
       }));
       
-      // String 2 (A), fret 3 should be C (A + 3 semitones = C)
+      // String 2 (B), fret 3 should be D (B + 3 semitones = D)
       const string2Fret3 = screen.getByTestId('fret-position-3-2').querySelector('circle[role="button"]');
       fireEvent.click(string2Fret3!);
       expect(onFretClick).toHaveBeenCalledWith(expect.objectContaining({
         fret: 3,
         string: 2,
-        note: 'C'
+        note: 'D'
       }));
     });
 

--- a/src/design-system/components/Fretboard/Fretboard.tsx
+++ b/src/design-system/components/Fretboard/Fretboard.tsx
@@ -79,11 +79,16 @@ export const Fretboard: React.FC<FretboardProps> = ({
 
   // Calculate note at specific fret position
   const calculateNote = useCallback((stringIndex: number, fret: number): NoteName => {
-    const openStringNote = tuning[stringIndex];
+    // Convert from visual string position (0-5) to tuning array index
+    // String 0 (visual top) = tuning[5] (high E)
+    // String 4 (5th string) = tuning[1] (A string) 
+    // String 5 (visual bottom) = tuning[0] (low E)
+    const tuningIndex = (stringCount - 1) - stringIndex;
+    const openStringNote = tuning[tuningIndex];
     const openStringIndex = CHROMATIC_NOTES.indexOf(openStringNote);
     const noteIndex = (openStringIndex + fret) % 12;
     return CHROMATIC_NOTES[noteIndex];
-  }, [tuning]);
+  }, [tuning, stringCount]);
 
   // Memoized fret positions for performance
   const fretPositions = useMemo(() => {

--- a/src/design-system/components/Fretboard/string-mapping-bug.test.tsx
+++ b/src/design-system/components/Fretboard/string-mapping-bug.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * TDD Test for String Mapping Bug
+ * 
+ * Tests the specific bug reported: "5th string (A string) at fret 1 should show A# but shows C"
+ * This is a focused test to verify the fix before implementing it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Fretboard } from './Fretboard';
+
+describe('String Mapping Bug Fix (TDD)', () => {
+  it('5th string (A) shows correct notes - the reported bug', () => {
+    render(<Fretboard fretCount={3} showNoteLabels={true} />);
+    
+    // Find the circle elements that have the aria-label
+    const string5Open = screen.getByTestId('fret-position-0-5').querySelector('circle[role="button"]');
+    const string5Fret1 = screen.getByTestId('fret-position-1-5').querySelector('circle[role="button"]');
+    const string5Fret2 = screen.getByTestId('fret-position-2-5').querySelector('circle[role="button"]');
+    
+    // CURRENT BUG: These tests will fail because string indexing is wrong
+    // String 5 (A string) should show: A, A#, B
+    // But currently shows: B, C, C# (off by 3 semitones)
+    
+    expect(string5Open).toHaveAttribute('aria-label', expect.stringContaining('note A'));
+    expect(string5Fret1).toHaveAttribute('aria-label', expect.stringContaining('note A#'));
+    expect(string5Fret2).toHaveAttribute('aria-label', expect.stringContaining('note B'));
+  });
+
+  it('all strings show correct open string notes', () => {
+    render(<Fretboard fretCount={0} showNoteLabels={true} />);
+    
+    // Standard tuning (visual order top to bottom): E B G D A E
+    const string1 = screen.getByTestId('fret-position-0-1').querySelector('circle[role="button"]');
+    const string2 = screen.getByTestId('fret-position-0-2').querySelector('circle[role="button"]');  
+    const string3 = screen.getByTestId('fret-position-0-3').querySelector('circle[role="button"]');
+    const string4 = screen.getByTestId('fret-position-0-4').querySelector('circle[role="button"]');
+    const string5 = screen.getByTestId('fret-position-0-5').querySelector('circle[role="button"]');
+    const string6 = screen.getByTestId('fret-position-0-6').querySelector('circle[role="button"]');
+    
+    // String 1 (top) = High E
+    expect(string1).toHaveAttribute('aria-label', expect.stringContaining('note E'));
+    // String 2 = B  
+    expect(string2).toHaveAttribute('aria-label', expect.stringContaining('note B'));
+    // String 3 = G
+    expect(string3).toHaveAttribute('aria-label', expect.stringContaining('note G')); 
+    // String 4 = D
+    expect(string4).toHaveAttribute('aria-label', expect.stringContaining('note D'));
+    // String 5 = A (THE BUG - currently showing B)
+    expect(string5).toHaveAttribute('aria-label', expect.stringContaining('note A'));
+    // String 6 (bottom) = Low E  
+    expect(string6).toHaveAttribute('aria-label', expect.stringContaining('note E'));
+  });
+
+  it('verifies the STANDARD_TUNING array is correct', () => {
+    // This test verifies our understanding of the data structure
+    // STANDARD_TUNING: ['E', 'A', 'D', 'G', 'B', 'E'] represents strings 6 to 1
+    // But the bug is in how we map string numbers (1-6) to array indices (0-5)
+    
+    render(<Fretboard fretCount={0} showNoteLabels={true} />);
+    
+    // EXPECTED mapping (what SHOULD happen):
+    // String 1 (visual top) -> STANDARD_TUNING[5] = 'E' (high E)
+    // String 2 -> STANDARD_TUNING[4] = 'B' 
+    // String 3 -> STANDARD_TUNING[3] = 'G'
+    // String 4 -> STANDARD_TUNING[2] = 'D'
+    // String 5 -> STANDARD_TUNING[1] = 'A' ← THE BUG IS HERE
+    // String 6 (visual bottom) -> STANDARD_TUNING[0] = 'E' (low E)
+    
+    // The fix should be: tuning[6 - stringNumber] instead of tuning[stringIndex]
+    
+    const string5 = screen.getByTestId('fret-position-0-5').querySelector('circle[role="button"]');
+    expect(string5).toHaveAttribute('aria-label', expect.stringContaining('note A'));
+  });
+});

--- a/src/design-system/components/TriadSelector/TriadSelector.tsx
+++ b/src/design-system/components/TriadSelector/TriadSelector.tsx
@@ -120,7 +120,12 @@ export const TriadSelector: React.FC<TriadSelectorProps> = ({
     const searchRange = { min: Math.max(0, neckFret - 2), max: neckFret + 5 };
     
     for (let stringIndex = 0; stringIndex < 6; stringIndex++) {
-      const openStringNote = STANDARD_TUNING[stringIndex];
+      // Convert from visual string position (0-5) to tuning array index
+      // String 0 (visual top) = tuning[5] (high E)
+      // String 4 (5th string) = tuning[1] (A string) 
+      // String 5 (visual bottom) = tuning[0] (low E)
+      const tuningIndex = (6 - 1) - stringIndex;
+      const openStringNote = STANDARD_TUNING[tuningIndex];
       const openStringIndex = CHROMATIC_NOTES.indexOf(openStringNote);
       
       for (let fret = searchRange.min; fret <= searchRange.max; fret++) {


### PR DESCRIPTION
## Summary
- Fixed critical bug where guitar strings were displaying incorrect notes
- 5th string (A) was showing C instead of A# at fret 1
- All strings were affected due to incorrect array indexing

## Problem
The bug was in the string-to-tuning array mapping. The `STANDARD_TUNING` array `['E', 'A', 'D', 'G', 'B', 'E']` represents strings from 6th to 1st (low to high), but the code was treating indices as if they went from 1st to 6th.

### Reported Issue
> "I think notes on strings are wrong. For example the 5th string (the second from bottom), it's A when open, so first position should be Bflat but it says C"

## Solution
Implemented correct mapping with `tuningIndex = (stringCount - 1) - stringIndex`:
- String 1 (visual top, high E) → `tuning[5]` = 'E' ✅
- String 5 (A string) → `tuning[1]` = 'A' ✅ (was showing B)
- String 6 (visual bottom, low E) → `tuning[0]` = 'E' ✅

## Changes
1. **Fixed `Fretboard.tsx`**: Updated `calculateNote()` function with correct string mapping
2. **Fixed `TriadSelector.tsx`**: Updated `fretPositions` calculation with same mapping
3. **Added TDD tests**: Created `string-mapping-bug.test.tsx` with comprehensive tests
4. **Updated existing test**: Fixed one test that had incorrect expectation

## Test Results
All tests pass ✅
- New TDD tests (3/3) ✅
- Existing Fretboard tests (27/27) ✅
- String 5 now correctly shows A, A#, B, C... instead of B, C, C#, D...

## Verification
```bash
npm test -- --run string-mapping-bug.test.tsx
npm test -- --run Fretboard.test.tsx
```

This was a critical bug affecting the core functionality of the fretboard visualization. The fix ensures all guitar strings now display the correct notes at each fret position.