### PR TITLE
feat: update @types/react to 19.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.2.1",
-    "@types/react": "^19.1.9",
+    "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^2.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))
       '@storybook/addon-docs':
         specifier: ^9.1.1
-        version: 9.1.1(@types/react@19.1.9)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))
+        version: 9.1.1(@types/react@19.1.10)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))
       '@storybook/addon-onboarding':
         specifier: ^9.1.1
         version: 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))
@@ -47,7 +47,7 @@ importers:
         version: 6.6.4
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -55,11 +55,11 @@ importers:
         specifier: ^24.2.1
         version: 24.2.1
       '@types/react':
-        specifier: ^19.1.9
-        version: 19.1.9
+        specifier: ^19.1.10
+        version: 19.1.10
       '@types/react-dom':
         specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.9)
+        version: 19.1.7(@types/react@19.1.10)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
         version: 5.0.0(vite@5.4.19(@types/node@24.2.1))
@@ -909,8 +909,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
 
-  '@types/react@19.1.9':
-    resolution: {integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==}
+  '@types/react@19.1.10':
+    resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
@@ -2266,10 +2266,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/react@3.1.0(@types/react@19.1.9)(react@19.1.1)':
+  '@mdx-js/react@3.1.0(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.1.9
+      '@types/react': 19.1.10
       react: 19.1.1
 
   '@neoconfetti/react@1.0.0': {}
@@ -2355,9 +2355,9 @@ snapshots:
       axe-core: 4.10.3
       storybook: 9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1))
 
-  '@storybook/addon-docs@9.1.1(@types/react@19.1.9)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))':
+  '@storybook/addon-docs@9.1.1(@types/react@19.1.10)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))':
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@19.1.9)(react@19.1.1)
+      '@mdx-js/react': 3.1.0(@types/react@19.1.10)(react@19.1.1)
       '@storybook/csf-plugin': 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))
       '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@storybook/react-dom-shim': 9.1.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.2(@testing-library/dom@10.4.1)(vite@5.4.19(@types/node@24.2.1)))
@@ -2478,15 +2478,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.2
       '@testing-library/dom': 10.4.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
-      '@types/react': 19.1.9
-      '@types/react-dom': 19.1.7(@types/react@19.1.9)
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -2531,11 +2531,11 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
-  '@types/react-dom@19.1.7(@types/react@19.1.9)':
+  '@types/react-dom@19.1.7(@types/react@19.1.10)':
     dependencies:
-      '@types/react': 19.1.9
+      '@types/react': 19.1.10
 
-  '@types/react@19.1.9':
+  '@types/react@19.1.10':
     dependencies:
       csstype: 3.1.3
 


### PR DESCRIPTION
Updates `@types/react` from 19.1.9 to 19.1.10 to maintain consistency with the React ecosystem and ensure access to the latest type definitions.

## Changes
- Updates `@types/react` to `^19.1.10` (latest available)
- Keeps `@types/react-dom` at `^19.1.7` (latest available)
- Maintains compatibility with React 19.1.1 runtime packages

## Validation
- ✅ TypeScript compilation passes without errors
- ✅ Production build succeeds
- ✅ Pre-commit and pre-push hooks pass

## Notes
Runtime packages (`react@19.1.1`, `react-dom@19.1.1`) remain at latest stable versions as `@types` packages are typically updated more frequently than runtime packages.